### PR TITLE
Clone from image to volume

### DIFF
--- a/glance_store/_drivers/sheepdog.py
+++ b/glance_store/_drivers/sheepdog.py
@@ -33,7 +33,7 @@ import glance_store.location
 # glance-imageだと分かるようなスナップショットの名前が良いか?
 # magicナンバー的に1としても良いのであれば、この定義は不要
 # cinder側へも変更が必要
-DEFAULT_SNAPNAME='snap'
+DEFAULT_SNAPNAME = 'snap'
 
 LOG = logging.getLogger(__name__)
 
@@ -93,9 +93,11 @@ class SheepdogImage(object):
         Read up to 'count' bytes from this image starting at 'offset' and
         return the data.
 
-        Sheepdog Usage: dog vdi read -s snap_name -a address -p port image offset len
+        Sheepdog Usage:
+                 dog vdi read -s snap -a address -p port image offset len
         """
-        return self._run_command("read -s %s" % DEFAULT_SNAPNAME, None, str(offset), str(count))
+        return self._run_command("read -s %s" % DEFAULT_SNAPNAME,
+                                 None, str(offset), str(count))
 
     def write(self, data, offset, count):
         """
@@ -122,12 +124,13 @@ class SheepdogImage(object):
         """
         self._run_command("delete", None)
 
-    # glance-imageをsnapshotで保持するように変更するため, snapshot取得と削除用関数追加
+    # glance-imageをsnapshotで保持するように変更するため,
+    # snapshot取得と削除用関数追加
     def create_snapshot(self):
         """
         Create this image in the Sheepdog cluster with size 'size'.
 
-        Sheepdog Usage: dog vdi create -a address -p port -s snap_name image size
+        Sheepdog Usage: dog vdi create -s snap -a address -p port image size
         """
         self._run_command("snapshot -s %s" % DEFAULT_SNAPNAME, None)
 
@@ -135,7 +138,7 @@ class SheepdogImage(object):
         """
         Create this image in the Sheepdog cluster with size 'size'.
 
-        Sheepdog Usage: dog vdi create -a address -p port -s snap_name image size
+        Sheepdog Usage: dog vdi create -s snap -a address -p port image size
         """
         self._run_command("delete -s %s" % DEFAULT_SNAPNAME, None)
 
@@ -344,4 +347,4 @@ class Store(glance_store.driver.Store):
         # try-exceptでのエラーハンドリングは未だ実装していない
         # glance-imageはsnapshotで保持するために, glance-imageの削除は
         # snapshotの削除に相当
-	image.delete_snapshot()
+        image.delete_snapshot()

--- a/glance_store/_drivers/sheepdog.py
+++ b/glance_store/_drivers/sheepdog.py
@@ -59,7 +59,7 @@ class SheepdogImage(object):
         self.chunk_size = chunk_size
 
     def _run_command(self, command, data, *params):
-        cmd = ("collie vdi %(command)s -a %(addr)s -p %(port)d %(name)s "
+        cmd = ("dog vdi %(command)s -a %(addr)s -p %(port)d %(name)s "
                "%(params)s" %
                {"command": command,
                 "addr": self.addr,
@@ -78,7 +78,7 @@ class SheepdogImage(object):
         """
         Return the size of the this iamge
 
-        Sheepdog Usage: collie vdi list -r -a address -p port image
+        Sheepdog Usage: dog vdi list -r -a address -p port image
         """
         out = self._run_command("list -r", None)
         return long(out.split(' ')[3])
@@ -88,7 +88,7 @@ class SheepdogImage(object):
         Read up to 'count' bytes from this image starting at 'offset' and
         return the data.
 
-        Sheepdog Usage: collie vdi read -a address -p port image offset len
+        Sheepdog Usage: dog vdi read -a address -p port image offset len
         """
         return self._run_command("read", None, str(offset), str(count))
 
@@ -97,7 +97,7 @@ class SheepdogImage(object):
         Write up to 'count' bytes from the data to this image starting at
         'offset'
 
-        Sheepdog Usage: collie vdi write -a address -p port image offset len
+        Sheepdog Usage: dog vdi write -a address -p port image offset len
         """
         self._run_command("write", data, str(offset), str(count))
 
@@ -105,7 +105,7 @@ class SheepdogImage(object):
         """
         Create this image in the Sheepdog cluster with size 'size'.
 
-        Sheepdog Usage: collie vdi create -a address -p port image size
+        Sheepdog Usage: dog vdi create -a address -p port image size
         """
         self._run_command("create", None, str(size))
 
@@ -113,7 +113,7 @@ class SheepdogImage(object):
         """
         Delete this image in the Sheepdog cluster
 
-        Sheepdog Usage: collie vdi delete -a address -p port image
+        Sheepdog Usage: dog vdi delete -a address -p port image
         """
         self._run_command("delete", None)
 
@@ -121,7 +121,7 @@ class SheepdogImage(object):
         """
         Check if this image exists in the Sheepdog cluster via 'list' command
 
-        Sheepdog Usage: collie vdi list -r -a address -p port image
+        Sheepdog Usage: dog vdi list -r -a address -p port image
         """
         out = self._run_command("list -r", None)
         if not out:
@@ -205,7 +205,7 @@ class Store(glance_store.driver.Store):
                                                    reason=reason)
 
         try:
-            processutils.execute("collie", shell=True)
+            processutils.execute("dog", shell=True)
         except processutils.ProcessExecutionError as exc:
             reason = _("Error in store configuration: %s") % exc
             LOG.error(reason)


### PR DESCRIPTION
glanceイメージをcurrentイメージでの保存から, snapshotで保存するように
変更してみました.
cinder側も変更が必要なのですが、そちらは別途pull request送ります

正常系だけ確認するための変更なのでエラーハンドリングはまだきちんとかいてません.
